### PR TITLE
Commands/suggest

### DIFF
--- a/DiscordBot.BotCommands/Commands/Suggest/SuggestCommand.cs
+++ b/DiscordBot.BotCommands/Commands/Suggest/SuggestCommand.cs
@@ -1,0 +1,145 @@
+﻿using System.Linq;
+using System;
+using System.Threading.Tasks;
+using Discord.WebSocket;
+using Discord;
+using DiscordBot.StaticValues;
+
+namespace DiscordBot.BotCommands.Commands.Suggest
+{
+    public class SuggestCommand : IPrivateMessageCommand
+    {
+        /// <summary>
+        /// Sends an anonymized suggestion message. Either publicly in the "Suggestions" channel,
+        /// or privately to the specified Caretaker (in case its a suggestion or problem that shouldn't be discussed publicly)
+        /// Usage:
+        ///     !!suggest public suggestion_text
+        /// Or:
+        ///     !!suggest private target_username suggestion_text
+        /// </summary>
+        private readonly DiscordSocketClient _discordClient;
+
+        private const string USAGE_INFO = "```Usage:\n!!suggest public <suggestion text>\nOr:\n!!suggest private <target username> <suggestion text>```";
+
+        public SuggestCommand(DiscordSocketClient discordClient)
+        {
+            _discordClient = discordClient;
+        }
+
+        public bool CanExecute(SocketMessage message)
+        {
+            return message.Content.StartsWith("!!suggest");
+        }
+
+        public async Task Execute(SocketMessage message)
+        {
+            //Limited to users of role "Cow" to avoid abuse
+            var userRoles = _discordClient.GetGuild(GuildIds.FortuneFavoured).GetUser(message.Author.Id).Roles;
+            if (!userRoles.Any(e => e.Id == RoleIds.Cow))
+            {
+                await message.Channel.SendMessageAsync("You have no permission to use this command.");
+                return;
+            }
+
+            string messageContent = message.Content.Replace("!!suggest", "");
+
+            string target = GetSuggestionTarget(messageContent);
+
+            //remove target string from command
+            messageContent = messageContent.Trim();
+            int index = messageContent.IndexOf(" ");
+            messageContent = messageContent.Substring(messageContent.IndexOf(" ") + 1);
+
+            try
+            {
+                //index == -1 => incomplete command
+                if (target == "public" && index != -1)
+                {
+                    await SendPublicSuggestion(messageContent);
+                }
+                else if (target == "private" && index != -1)
+                {
+                    await SendPrivateSuggestion(messageContent);
+                }
+                else
+                {
+                    throw new Exception("Invalid suggestion target. Please specify whether the suggestion is to be send **public** or **private**.");
+                }
+
+                if (!(message.Channel is IPrivateChannel))  //can't delete DMs
+                {
+                    await message.DeleteAsync();
+                }
+            }
+            catch (Exception e)
+            {
+                await message.Channel.SendMessageAsync(e.Message + "\n" + USAGE_INFO);
+            }
+        }
+
+        private static Embed CreateSuggestionEmbed(string suggestion)
+        {
+            var embedBuilder = new EmbedBuilder();
+            embedBuilder.Color = Color.Green;
+            embedBuilder.Title = "Anonymous Suggestion";
+            embedBuilder.Description = suggestion;
+            return embedBuilder.Build();
+        }
+
+        private static string GetSuggestionTarget(string message)
+        {
+            return message.Trim().Split(" ", 2).First().ToLower();
+        }
+
+        private async Task SendPublicSuggestion(string suggestion)
+        {
+            await (_discordClient.GetChannel(ChannelIds.Suggestions) as ISocketMessageChannel).SendMessageAsync(null, false, CreateSuggestionEmbed(suggestion));
+        }
+
+        private async Task SendPrivateSuggestion(string message)
+        {
+            string[] arrMessage = message.Trim().Split(" ", 2);
+            if (arrMessage.Length < 2)
+            {
+                throw new Exception("Missing target username.");
+            }
+            string targetUsername = arrMessage[0];
+            string suggestion = arrMessage[1];
+
+
+            var role = _discordClient.GetGuild(GuildIds.FortuneFavoured).GetRole(RoleIds.Caretaker);
+
+            var targetUser = FindTargetUserInRole(role, targetUsername);
+            if (targetUser == null)
+            {
+                throw new Exception("User " + targetUsername + " is not in group " + role.Name + ".");
+            }
+
+            var dmChannel = await targetUser.GetOrCreateDMChannelAsync();
+            await dmChannel.SendMessageAsync(null, false, CreateSuggestionEmbed(suggestion));
+            await dmChannel.CloseAsync();
+
+            return;
+        }
+
+        private SocketUser FindTargetUserInRole(SocketRole role, string targetUsername)
+        {
+            foreach (var member in role.Members)
+            {
+                if (!string.IsNullOrEmpty(member.Nickname))
+                {
+                    if (member.Nickname.ToLower() == targetUsername.ToLower())
+                    {
+                        return member;
+                    }
+                }
+
+                if (member.Username.ToLower() == targetUsername.ToLower())
+                {
+                    return member;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/DiscordBot.BotCommands/IPrivateMessageCommand.cs
+++ b/DiscordBot.BotCommands/IPrivateMessageCommand.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using Discord.WebSocket;
+
+namespace DiscordBot.BotCommands
+{
+    /// <summary>
+    /// Marker interface to distinquish commands that can be run via private message to the bot.
+    /// </summary>
+    public interface IPrivateMessageCommand : ICommand{ }
+}

--- a/DiscordBot.EntryPoint/BotWorker.cs
+++ b/DiscordBot.EntryPoint/BotWorker.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.WebSocket;
 using DiscordBot.EntryPoint.CommandExecution;
+using DiscordBot.StaticValues;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -33,7 +34,7 @@ namespace DiscordBot.EntryPoint
                     try
                     {
                         var channel =
-                            _discordClient.GetGuild(685492295386398780).GetChannel(757206506566320128) as
+                            _discordClient.GetGuild(GuildIds.FortuneFavoured).GetChannel(757206506566320128) as
                                 IMessageChannel;
                         channel.SendMessageAsync($"Successful redeploy on Azure {DateTime.Now.ToLongTimeString()}")
                             .GetAwaiter().GetResult();

--- a/DiscordBot.EntryPoint/CommandExecution/CommandHandler.cs
+++ b/DiscordBot.EntryPoint/CommandExecution/CommandHandler.cs
@@ -5,6 +5,7 @@ using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 using ICommand = DiscordBot.BotCommands.ICommand;
+using IPrivateMessageCommand = DiscordBot.BotCommands.IPrivateMessageCommand;
 
 namespace DiscordBot.EntryPoint.CommandExecution
 {
@@ -28,15 +29,17 @@ namespace DiscordBot.EntryPoint.CommandExecution
                 return;
             }
             
-            if (message.Channel is IPrivateChannel)
-            {
-                return;
-            }
+            
             
             foreach (var command in _commands)
             {
                 try
                 {
+					if (message.Channel is IPrivateChannel)
+					{
+						if (!(command is IPrivateMessageCommand) continue;
+					}
+					
                     if (!command.CanExecute(message)) continue;
 
                     await command.Execute(message);

--- a/DiscordBot.EntryPoint/Initialize.cs
+++ b/DiscordBot.EntryPoint/Initialize.cs
@@ -6,6 +6,7 @@ using DiscordBot.BotCommands.Commands.Poll;
 using DiscordBot.BotCommands.Commands.Purge;
 using DiscordBot.BotCommands.Commands.Statistics;
 using DiscordBot.BotCommands.Commands.Hug;
+using DiscordBot.BotCommands.Commands.Suggest;
 using DiscordBot.DataAccess;
 using DiscordBot.EntryPoint.CommandExecution;
 using Microsoft.Extensions.DependencyInjection;
@@ -42,6 +43,7 @@ namespace DiscordBot.EntryPoint
             services.AddSingleton<ICommand, PurgeCommand>();
             services.AddSingleton<ICommand, StatisticsCommand>();
             services.AddSingleton<ICommand, HugCommand>();
+            services.AddSingleton<ICommand, SuggestCommand>();
         }
 
         public static void RegisterWorker(HostBuilderContext hostContext, IServiceCollection services)

--- a/DiscordBot.StaticValues/ChannelIds.cs
+++ b/DiscordBot.StaticValues/ChannelIds.cs
@@ -1,0 +1,7 @@
+﻿namespace DiscordBot.StaticValues
+{
+    public class ChannelIds
+    {
+        public static ulong Suggestions = 689093890027945985;
+    }
+}

--- a/DiscordBot.StaticValues/GuildIds.cs
+++ b/DiscordBot.StaticValues/GuildIds.cs
@@ -1,0 +1,7 @@
+﻿namespace DiscordBot.StaticValues
+{
+    public class GuildIds
+    {
+        public static ulong FortuneFavoured = 685492295386398780;
+    }
+}

--- a/DiscordBot.StaticValues/RoleIds.cs
+++ b/DiscordBot.StaticValues/RoleIds.cs
@@ -1,0 +1,8 @@
+﻿namespace DiscordBot.StaticValues
+{
+    public class RoleIds
+    {
+        public static ulong Cow = 759348433026154506;
+        public static ulong Caretaker = 749579813701943357;
+    }
+}


### PR DESCRIPTION
Added a new `!!suggest` command to provide a way to send anonymous suggestions, either to the _Suggestion_ channel or directly to one of the caretakers.

Added several channel and role ids to be used in the command.

Also changed the message handler, so that specific commands can be used via private messsages to the bot.

```
Usage:
    !!suggest public <suggestion text>
Or:
    !!suggest private <target username> <suggestion text>
```